### PR TITLE
Filter for x86_64 architecture

### DIFF
--- a/bin/aws-snapshot-recovery
+++ b/bin/aws-snapshot-recovery
@@ -101,7 +101,8 @@ def parse_configuration_cli(config):
 def get_latest_debian_ami_id():
   amis = aws_ec2_resource.images.filter(
     Filters=[
-      {'Name':'owner-id', 'Values':['379101102735']}
+      {'Name':'owner-id', 'Values':['379101102735']},
+      {'Name':'architecture', 'Values': ['x86_64']},
     ]
   )
   return sorted(list(amis), key=lambda image:image.creation_date)[-1].id


### PR DESCRIPTION
Je sait pas si `arm64` est requis pour certaines personnes, mais j'ai ajouté un filtre sur l'architecture x86_64 pour corriger le problème suivant : 

```
botocore.exceptions.ClientError: An error occurred (InvalidParameterValue) when calling the RunInstances operation: The requested instance type's architecture (x86_64) does not match the architecture in the manifest for ami-07ca4441ab358e98a (arm64)
```